### PR TITLE
Add support for event properties

### DIFF
--- a/defold-rive/api/rive.script_api
+++ b/defold-rive/api/rive.script_api
@@ -98,7 +98,7 @@
 
           - name: message
             type: table
-            desc: A table that contains the event propertiesresponse
+            desc: A table that contains the event properties
 
 #*****************************************************************************************************
 

--- a/defold-rive/api/rive.script_api
+++ b/defold-rive/api/rive.script_api
@@ -84,6 +84,22 @@
             type: constant
             desc: The rate with which the animation will be played. Must be positive.
 
+      - name: callback_function
+        type: function
+        desc: function to call when a playback event occurs
+        parameters:
+          - name: self
+            type: object
+            desc: The context of the calling script
+
+          - name: message_id
+            type: hash
+            desc: The name of the event
+
+          - name: message
+            type: table
+            desc: A table that contains the event propertiesresponse
+
 #*****************************************************************************************************
 
   - name: cancel

--- a/defold-rive/src/comp_rive.h
+++ b/defold-rive/src/comp_rive.h
@@ -14,6 +14,7 @@
 #define DM_GAMESYS_COMP_RIVE_H
 
 #include <stdint.h>
+#include <dmsdk/sdk.h>
 #include <dmsdk/dlib/hash.h>
 #include <dmsdk/dlib/vmath.h>
 #include <dmsdk/dlib/transform.h>
@@ -35,7 +36,7 @@ namespace dmRive
     struct RiveBuffer;
 
     // callback for event trigger
-    typedef void (*RiveEventCallback)(void* callback_data, dmMessage::URL component, const char* event_name);
+    typedef void (*RiveEventCallback)(void* callback_data, dmMessage::URL component, rive::Event* event);
 
     // struct to hold script callback data for events
     struct RiveEventCallbackData
@@ -90,6 +91,9 @@ namespace dmRive
     // Get the game object identifier
     bool CompRiveGetBoneID(RiveComponent* component, dmhash_t bone_name, dmhash_t* id);
     
+    void CompRivePushEventName(lua_State* L, rive::Event* event);
+    void CompRivePushEventProperties(lua_State* L, rive::Event* event);
+
     void CompRivePointerMove(RiveComponent* component, float x, float y);
     void CompRivePointerUp(RiveComponent* component, float x, float y);
     void CompRivePointerDown(RiveComponent* component, float x, float y);

--- a/defold-rive/src/script_rive.cpp
+++ b/defold-rive/src/script_rive.cpp
@@ -102,7 +102,7 @@ namespace dmRive
         return 0;
     }
 
-    void OnRiveEvent(void* callback_data, dmMessage::URL component, const char* event_name)
+    void OnRiveEvent(void* callback_data, dmMessage::URL component, rive::Event* event)
     {
         RiveEventCallbackData* event_callback_data = (RiveEventCallbackData*)callback_data;
 
@@ -125,9 +125,9 @@ namespace dmRive
             return;
         }
 
-        // dmScript::PushURL(L, component);
-        lua_pushstring(L, event_name);
-        dmScript::PCall(L, 2, 0);
+        CompRivePushEventName(L, event);
+        CompRivePushEventProperties(L, event);
+        dmScript::PCall(L, 3, 0);
 
         dmScript::TeardownCallback(lua_callback);
     }

--- a/main/fighting-game/fighting-game.script
+++ b/main/fighting-game/fighting-game.script
@@ -1,11 +1,9 @@
 function init(self)
-	--rive.play_anim("#model", "panelAnimateOn", go.PLAYBACK_LOOP_FORWARD)
-	--rive.play_anim("#model", "cape", go.PLAYBACK_LOOP_FORWARD)
-	--rive.play_anim("#model", "bodyLoop", go.PLAYBACK_LOOP_FORWARD)
 	msg.post(".", "acquire_input_focus")
 
 	rive.play_state_machine("#model", "State Machine 1", nil, function(self, message_id, message)
 		print("play_state_machine", message_id)
+		pprint(message)
 	end)
 	
 


### PR DESCRIPTION
This change adds event properties to the `rive.play_state_machine(url, id, options, callback)` callback message.

Fixes #75 