### PR TITLE
fix(oob): handle response.status 304 not modified

### DIFF
--- a/main/outofband/outofband.script
+++ b/main/outofband/outofband.script
@@ -44,7 +44,7 @@ function init(self)
 				print("HTTP REQUEST", URL)
 				http.request(URL, "GET", function (self, _id, response)
 					print("  response.status:", response.status)
-					if response.status == 200 or response.status == 206 then
+					if response.status == 200 or response.status == 206 or response.status == 304 then
 						local rivc = go.get(RIVE_MODEL, "rive_file")
 						rive.riv_swap_asset(rivc, "walle.jpg", { payload = response.response })
 					end


### PR DESCRIPTION
When you first run the `outofband` example, the remotely loaded Defold logo resource replaces the walle.jpg asset appropriately. However, on subsequent runs it does not replace it since the server starts returning response status code 304 for not modified.