### PR TITLE
Reset to camera projection before drawing sprites and particles

### DIFF
--- a/defold-rive/lua/rive.render_script
+++ b/defold-rive/lua/rive.render_script
@@ -194,7 +194,10 @@ function update(self)
     -- Rive rendering
     render.set_projection(rive.get_projection_matrix())
     render.draw(predicates.rive)
-    
+
+    -- render the other components: sprites, tilemaps, particles etc
+    --
+    render.set_projection(camera_world.proj)
     render.draw(predicates.tile, camera_world.frustum)
     render.draw(predicates.particle, camera_world.frustum)
     render.disable_state(graphics.STATE_DEPTH_TEST)


### PR DESCRIPTION
This change makes sure the camera projection is used before drawing sprites, tilemaps, particle effects etc.

Fixes #221 
Fixes #220 