### PR TITLE
Fixes for defold/editor-model-performance branch

### DIFF
--- a/defold-rive/editor/resources/materials/rivemodel_selection.fp
+++ b/defold-rive/editor/resources/materials/rivemodel_selection.fp
@@ -1,0 +1,64 @@
+#version 140
+
+#define FILL_TYPE_SOLID 0
+#define FILL_TYPE_LINEAR 1
+#define FILL_TYPE_RADIAL 2
+#define FILL_TYPE_TEXTURED 3
+#define MAX_COLORS 16
+#define MAX_STOPS 4
+
+in highp vec2 var_texcoord0;
+in highp vec2 var_gradient_uv;
+
+uniform fs_uniforms {
+    lowp vec4 colors[MAX_COLORS];
+    mediump vec4 stops[MAX_STOPS];
+    highp vec4 gradientLimits;
+    highp vec4 properties; // x: filltype, y: stopcount
+    lowp vec4 id_color;
+};
+
+uniform mediump sampler2D texture_sampler;
+
+out lowp vec4 out_color;
+
+void main() {
+    vec2 gradientStart = gradientLimits.xy;
+    vec2 gradientStop = gradientLimits.zw;
+    int iStopCount = int(properties.y);
+    int iFillType = int(properties.x);
+    float alpha = 0.0;
+
+    if (iFillType == FILL_TYPE_SOLID) {
+        alpha = colors[0].a;
+    } else if (iFillType == FILL_TYPE_TEXTURED) {
+        alpha = texture(texture_sampler, var_texcoord0).a * colors[0].a;
+    } else {
+        int stop_cur = 1;
+        int stop_next = stop_cur + 1;
+        float f = iFillType == FILL_TYPE_LINEAR ? var_gradient_uv.x : length(var_gradient_uv);
+        float t = smoothstep(stops[0][0], stops[0][1], f);
+        alpha = mix(colors[0].a, colors[1].a, t);
+
+        for (int i = 1; i < 15; ++i) {
+            if (i >= iStopCount - 1) {
+                break;
+            }
+
+            t = smoothstep(stops[i / 4][stop_cur], stops[(i + 1) / 4][stop_next], f);
+            alpha = mix(alpha, colors[i + 1].a, t);
+            stop_cur = stop_next;
+            stop_next = stop_next + 1;
+
+            if (stop_next >= 4) {
+                stop_next = stop_next - 4;
+            }
+        }
+    }
+
+    if (alpha > 0.05) {
+        out_color = id_color;
+    } else {
+        out_color = vec4(0.0);
+    }
+}

--- a/defold-rive/editor/resources/materials/rivemodel_selection.material
+++ b/defold-rive/editor/resources/materials/rivemodel_selection.material
@@ -1,0 +1,54 @@
+name: "rivemodel_selection"
+tags: "rive"
+vertex_program: "/defold-rive/editor/resources/materials/rivemodel_selection.vp"
+fragment_program: "/defold-rive/editor/resources/materials/rivemodel_selection.fp"
+vertex_constants {
+  name: "world_view_proj"
+  type: CONSTANT_TYPE_WORLDVIEWPROJ
+}
+fragment_constants {
+  name: "colors"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 0.25
+    z: 0.25
+    w: 1.0
+  }
+}
+fragment_constants {
+  name: "stops"
+  type: CONSTANT_TYPE_USER
+  value {
+  }
+}
+fragment_constants {
+  name: "properties"
+  type: CONSTANT_TYPE_USER
+  value {
+  }
+}
+fragment_constants {
+  name: "gradientLimits"
+  type: CONSTANT_TYPE_USER
+  value {
+  }
+}
+fragment_constants {
+  name: "id_color"
+  type: CONSTANT_TYPE_USER
+  value {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+    w: 1.0
+  }
+}
+samplers {
+  name: "texture_sampler"
+  wrap_u: WRAP_MODE_REPEAT
+  wrap_v: WRAP_MODE_REPEAT
+  filter_min: FILTER_MODE_MIN_LINEAR_MIPMAP_LINEAR
+  filter_mag: FILTER_MODE_MAG_LINEAR
+  max_anisotropy: 0.0
+}

--- a/defold-rive/editor/resources/materials/rivemodel_selection.vp
+++ b/defold-rive/editor/resources/materials/rivemodel_selection.vp
@@ -1,0 +1,36 @@
+#version 140
+
+#define FILL_TYPE_SOLID 0
+#define FILL_TYPE_LINEAR 1
+#define FILL_TYPE_RADIAL 2
+#define FILL_TYPE_TEXTURED 3
+
+in highp vec2 position;
+in highp vec2 texcoord0;
+
+uniform vs_uniforms {
+    highp mat4 world_view_proj;
+    highp vec4 transform_local[4];
+    highp vec4 gradientLimits;
+    highp vec4 properties; // x: filltype, y: stopcount
+};
+
+out highp vec2 var_texcoord0;
+out highp vec2 var_gradient_uv;
+
+void main() {
+    var_texcoord0 = texcoord0;
+    gl_Position = world_view_proj * vec4(position.xy, 0.0, 1.0);
+
+    int iFillType = int(properties.x);
+    vec2 gradientStart = gradientLimits.xy;
+    vec2 gradientStop = gradientLimits.zw;
+
+    if (iFillType == FILL_TYPE_LINEAR) {
+        vec2 toEnd  = gradientStop - gradientStart;
+        float lengthSquared = toEnd.x * toEnd.x + toEnd.y * toEnd.y;
+        var_gradient_uv.x = dot(position.xy - gradientStart, toEnd) / lengthSquared;
+    } else if (iFillType == FILL_TYPE_RADIAL) {
+        var_gradient_uv = (position.xy - gradientStart) / distance(gradientStart, gradientStop);
+    }
+}


### PR DESCRIPTION
* Fixes Scene View picking against Rive scenes.
* Removed unused `scene-structure` remnant from editor plugin.

Counterpart to defold/defold#11508